### PR TITLE
(chore) RECORD VITALS link opens the Triage form

### DIFF
--- a/distro/configuration/ampathforms/Triage.json
+++ b/distro/configuration/ampathforms/Triage.json
@@ -272,5 +272,5 @@
   "processor": "EncounterFormProcessor",
   "referencedForms": [],
   "encounterType": "3ccde6e2-9730-46a3-8f69-8a5e0cc48128",
-  "uuid": "1d87683a-fac0-3846-8b16-e3d2fad9bdf6"
+  "uuid": "1165eb3a-73f4-3cbe-ae87-a30a05d89b88"
 }

--- a/frontend/config-core_demo.json
+++ b/frontend/config-core_demo.json
@@ -215,7 +215,7 @@
     "vitals": {
       "useFormEngine": true,
       "formName": "1. Triage",
-      "formUuid": "6205a52d-eb0a-3b86-84b1-812858d272fb",
+      "formUuid": "1165eb3a-73f4-3cbe-ae87-a30a05d89b88",
       "encounterTypeUuid": "3ccde6e2-9730-46a3-8f69-8a5e0cc48128"
     },
     "concepts": {

--- a/frontend/config.json
+++ b/frontend/config.json
@@ -222,7 +222,7 @@
     "vitals": {
       "useFormEngine": true,
       "formName": "Record Triage Details",
-      "formUuid": "6205a52d-eb0a-3b86-84b1-812858d272fb",
+      "formUuid": "1165eb3a-73f4-3cbe-ae87-a30a05d89b88",
       "encounterTypeUuid": "3ccde6e2-9730-46a3-8f69-8a5e0cc48128"
     },
     "concepts": {


### PR DESCRIPTION
@moshonk 
The record vitals link would fail to redirect to open the triage form due to a mismatch in the formUuid