### PR TITLE
Add eHospital Web Services module to distribution

### DIFF
--- a/distro/distro.properties
+++ b/distro/distro.properties
@@ -40,3 +40,4 @@ omod.event=${event.version}
 omod.bedmanagement=${bedmanagement.version}
 omod.stockmanagement=${stockmanagement.version}
 omod.billing=${billing.version}
+omod.ehospitalws=${ehospitalws.version}

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -61,6 +61,7 @@
     <!-- Stock Management and Billing -->
     <stockmanagement.version>3.0.0</stockmanagement.version>
     <billing.version>2.2.0</billing.version>
+    <ehospitalws.version>1.0.1-SNAPSHOT</ehospitalws.version>
   </properties>
 
   <dependencies>
@@ -246,6 +247,12 @@
       <groupId>org.openmrs.module</groupId>
       <artifactId>billing-omod</artifactId>
       <version>${billing.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openmrs.module</groupId>
+      <artifactId>ehospitalws-omod</artifactId>
+      <version>${ehospitalws.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
Adds the **eHospital Web Services** module ([openmrs-module-ehospitalws](https://github.com/IntelliSOFT-Consulting/openmrs-module-ehospitalws)) to the distribution.

- `distro/distro.properties`: `omod.ehospitalws=${ehospitalws.version}`
- `distro/pom.xml`: `ehospitalws.version` property (`1.0.1-SNAPSHOT`) and `ehospitalws-omod` dependency (`org.openmrs.module`, scope `provided`)

## Note
The module is referenced at **1.0.1-SNAPSHOT**, so the build resolves it from a snapshot repo (or local `~/.m2` after `mvn install`). A released version should be published for reproducible release builds.

