### PR TITLE
Fix: Force no-cache build for frontend to pick up latest next-tagged …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,5 +32,5 @@ jobs:
             # Reset to origin/main to avoid stash-pop merge conflicts during deploy.
             # Any local server modifications will be discarded; keep config outside the repo.
             git reset --hard origin/main
-            docker compose build --build-arg CACHE_BUST=$(date +%s) frontend
+            docker compose -f docker-compose.yml -f docker-compose.override.yml build frontend --no-cache
             docker compose -f docker-compose.yml -f docker-compose.override.yml up -d --build --remove-orphans  


### PR DESCRIPTION
…ESM modules

docker compose up --build reuses the cached npx openmrs assemble layer whenever the Dockerfile/context is unchanged, so next-tagged packages (e.g. esm-patient-flags-app) never got re-resolved against npm and stayed pinned to whatever version was cached. Building with --no-cache first forces a fresh resolution before the subsequent up --build recreates the container.