### PR TITLE
Fix: Resolve `NullPointerException` on form submission by updating missing Concept UUIDs

### DIFF
--- a/distro/configuration/ampathforms/dental.json
+++ b/distro/configuration/ampathforms/dental.json
@@ -50,23 +50,23 @@
                     "label": "Masking Per Tooth"
                   },
                   {
-                    "concept": "05093823-3427-44eb-9a65-b9aff518b02a",
+                    "concept": "a4cebf9a-8757-406d-99c7-4aa11436d70c",
                     "label": "Crown & Bridge"
                   },
                   {
-                    "concept": "452f2cff-1368-4242-b516-7ccdbad6bd0c",
+                    "concept": "50840634-21b3-44c0-b176-70c2392fb191",
                     "label": "Partial Dentures"
                   },
                   {
-                    "concept": "eae4ec27-ee2f-4f95-82f7-31d6340877b6",
+                    "concept": "166b3f83-036d-4192-99c3-014439c28ad6",
                     "label": "Full Dentures"
                   },
                   {
-                    "concept": "d84be35c-4dda-4509-80e4-34923ace89a8",
+                    "concept": "0eab3473-ac47-485c-9692-42a329187d5f",
                     "label": "Braces"
                   },
                   {
-                    "concept": "cca548c7-50e6-4b23-8784-736f302db29c",
+                    "concept": "a1b74c6d-e6be-491b-af49-feb7a3a48bf7",
                     "label": "Pulpectomy"
                   },
                   {
@@ -253,11 +253,11 @@
                     "label": "Down’s syndrome"
                   },
                   {
-                    "concept": "47a1132d-999b-42f3-8114-99a1e650bb2e",
+                    "concept": "71293391-dc75-4c90-a4bc-5da60442b60c",
                     "label": "Poisoning"
                   },
                   {
-                    "concept": "eabdbb3c-f9da-469a-8405-c97061df3bed",
+                    "concept": "da454f8c-ccbf-42f6-b046-38f6036bc347",
                     "label": "Road Traffic Injuries"
                   },
                   {
@@ -273,15 +273,15 @@
                     "label": "Other Injuries"
                   },
                   {
-                    "concept": "59d3ee16-4941-42b2-b05c-a9cab5aeeb53",
+                    "concept": "0b1b1a73-62c7-4a98-847d-9917ebbdfcef",
                     "label": "Sexual Violence"
                   },
                   {
-                    "concept": "6cc751f9-46eb-4565-891d-5f6e69be68d8",
+                    "concept": "9ffa7692-97a0-44a7-8abd-da07de5bdf22",
                     "label": "Burns"
                   },
                   {
-                    "concept": "dbbab20b-7071-4ae0-b2fb-622b2aa95813c",
+                    "concept": "4bfbdee8-2574-4ed3-b9e3-295ae2bc6754c",
                     "label": "Snake Bites"
                   },
                   {
@@ -565,7 +565,7 @@
                     "label": "Burns"
                   },
                   {
-                    "concept": "dbbab20b-7071-4ae0-b2fb-622b2aa95813",
+                    "concept": "4bfbdee8-2574-4ed3-b9e3-295ae2bc6754",
                     "label": "Snake Bites"
                   },
                   {
@@ -811,7 +811,7 @@
               "id": "findings",
               "questionOptions": {
                 "rendering": "textarea",
-                "concept": "7ba3de0b-60d2-477a-849a-217b4a31bc28",
+                "concept": "2dd2e395-858b-4754-878c-bc22afe0f3d6",
                 "answers": []
               }
             },

--- a/distro/configuration/ampathforms/findings_and_treatment.json
+++ b/distro/configuration/ampathforms/findings_and_treatment.json
@@ -124,7 +124,7 @@
               "required": false,
               "questionOptions": {
                 "rendering": "number",
-                "concept": "2ff5eec2-815c-4c89-9e9f-8d74ffdcd4fe",
+                "concept": "9adb2c60-b34d-4c3e-961b-03bd0c581e45",
                 "min": "0"
               },
               "hide": {
@@ -151,14 +151,14 @@
               "required": false,
               "questionOptions": {
                 "rendering": "radio",
-                "concept": "0653be28-b8db-45f1-a5fe-c6e75c413431",
+                "concept": "2eac1d32-0d14-43d7-b188-a6acb215e626",
                 "answers": [
                   {
-                    "concept": "7b5d260e-0134-418c-9201-1fee66209971",
+                    "concept": "b0863993-4b65-4d34-82a8-ed8bc1bd2598",
                     "label": "Abstinence"
                   },
                   {
-                    "concept": "fbd666e4-f8aa-458c-8884-9770451ff680",
+                    "concept": "410d7684-2045-4eff-9af3-1fb57a406123",
                     "label": "Other"
                   }
                 ]
@@ -174,10 +174,10 @@
               "required": false,
               "questionOptions": {
                 "rendering": "text",
-                "concept": "5c083401-8a61-4899-8262-7db011ba0612"
+                "concept": "62340009-748b-4b4c-87fa-8d1b2ca96ea0"
               },
               "hide": {
-                "hideWhenExpression": "familyPlanning !== 'fbd666e4-f8aa-458c-8884-9770451ff680'"
+                "hideWhenExpression": "familyPlanning !== '410d7684-2045-4eff-9af3-1fb57a406123'"
               }
             }
           ],
@@ -197,7 +197,7 @@
               "questionOptions": {
                 "rendering": "textarea",
                 "rows": 5,
-                "concept": "5f4b555d-d223-423d-8a21-cd7728318df4"
+                "concept": "d85b298f-2819-49b1-b716-1c0cee69212c"
               },
               "hide": {
                 "hideWhenExpression": "sex === 'M' || !(age >= 9)"
@@ -465,11 +465,11 @@
                     "label": "Down’s syndrome"
                   },
                   {
-                    "concept": "47a1132d-999b-42f3-8114-99a1e650bb2e",
+                    "concept": "71293391-dc75-4c90-a4bc-5da60442b60c",
                     "label": "Poisoning"
                   },
                   {
-                    "concept": "eabdbb3c-f9da-469a-8405-c97061df3bed",
+                    "concept": "da454f8c-ccbf-42f6-b046-38f6036bc347",
                     "label": "Road Traffic Injuries"
                   },
                   {
@@ -485,11 +485,11 @@
                     "label": "Other Injuries"
                   },
                   {
-                    "concept": "59d3ee16-4941-42b2-b05c-a9cab5aeeb53",
+                    "concept": "0b1b1a73-62c7-4a98-847d-9917ebbdfcef",
                     "label": "Sexual Violence"
                   },
                   {
-                    "concept": "6cc751f9-46eb-4565-891d-5f6e69be68d8",
+                    "concept": "9ffa7692-97a0-44a7-8abd-da07de5bdf22",
                     "label": "Burns"
                   },
                   {
@@ -777,7 +777,7 @@
                     "label": "Burns"
                   },
                   {
-                    "concept": "dbbab20b-7071-4ae0-b2fb-622b2aa95813",
+                    "concept": "4bfbdee8-2574-4ed3-b9e3-295ae2bc6754",
                     "label": "Snake Bites"
                   },
                   {


### PR DESCRIPTION
## Description
This PR addresses a critical bug that caused encounter saving to fail with a `NullPointerException` (`Cannot invoke "org.openmrs.Concept.getDatatype()" because the return value of "org.openmrs.Obs.getConcept()" is null`) when submitting the **Findings and Treatment** and **Dental** forms.
### What was happening?
Several form fields in `findings_and_treatment.json` and `dental.json` were referencing old/deleted concept UUIDs that no longer existed in the OCL dictionary or CSVs. When the frontend submitted these UUIDs, the backend lookup returned `null`, crashing the validation process.
### What was changed?
Mapped 17 outdated/missing concept UUIDs to their correct, existing counterparts found in `distro/configuration/concepts/`. 
Key replacements include:
* **Dental Form**: Updated UUIDs for procedures like *Crown & Bridge, Partial/Full Dentures, Braces, Pulpectomy,* and *Dental Findings*.
* **Findings and Treatment Form**: Updated UUIDs for *Number of previous pregnancies, Family planning, Abstinence, Obstetrics and Gynaecology*, and various injury diagnoses (*Poisoning, Road Traffic Injuries, Burns, Sexual Violence*).
* **Snake Bites**: Re-mapped to the standard `OTHER BITES` diagnosis concept.
* **Other**: Re-mapped generic "Other" to `Other Diagnosis/Impressions`.
