### PR TITLE
Fix missing cause of death concepts in patient chart

### DIFF
--- a/distro/configuration/globalproperties/globalproperties-core_data.xml
+++ b/distro/configuration/globalproperties/globalproperties-core_data.xml
@@ -16,5 +16,9 @@
             <property>ehospitalreports.serializer.whitelist.types</property>
             <value>org.openmrs.module.ehospitalreports.**</value>
         </globalProperty>
+        <globalProperty>
+            <property>concept.causeOfDeath</property>
+            <value>9272a14b-7260-4353-9e5b-5787b5dead9d</value>
+        </globalProperty>
     </globalProperties>
 </config>


### PR DESCRIPTION
## Description
This PR resolves the issue where marking a patient as deceased would show the error: *"There are no cause of death concepts configured in the system to display for this patient"*.
The missing link was the `concept.causeOfDeath` global property which dictates which concept should be used to populate the cause of death options. 
### Changes made:
* Added the `concept.causeOfDeath` global property to `globalproperties-core_data.xml`, pointing to the correct Cause of death concept UUID (`9272a14b-7260-4353-9e5b-5787b5dead9d`).

## Before
<img width="1666" height="968" alt="Screenshot 2026-07-03 at 12 30 16 AM" src="https://github.com/user-attachments/assets/a496abae-cdab-4bf3-b23d-75c5d34f8428" />

## ScreenRecord

https://github.com/user-attachments/assets/9a39520b-4bc1-41ca-a289-4e3b567a0314

